### PR TITLE
denite.util. path2project is requires root_markers as 3rd argument

### DIFF
--- a/rplugin/python3/denite/source/rails.py
+++ b/rplugin/python3/denite/source/rails.py
@@ -38,7 +38,7 @@ class Source(Base):
 
         cbname = self.vim.current.buffer.name
         context['__cbname'] = cbname
-        context['__root_path'] = util.path2project(self.vim, cbname)
+        context['__root_path'] = util.path2project(self.vim, cbname, context.get('root_markers', ''))
 
     def highlight(self):
         # TODO syntax does not work as expected


### PR DESCRIPTION
changed at https://github.com/Shougo/denite.nvim/commit/ddda5859c2da4e8acebc70357994ce9290d8b2ac